### PR TITLE
Patch sorted hla input

### DIFF
--- a/prepareData/BuildLargeG.py
+++ b/prepareData/BuildLargeG.py
@@ -39,7 +39,7 @@ def buildLargeG():
     with open('LargeG.txt', 'w') as outFile:
         with open('OneElementG.txt', 'w') as oneElementGFile:
             with open('hla_nom_g.txt') as file:
-                for line in file:
+                for line in sorted(file):
                     if not line.startswith('#'):
                         line = line.rstrip('\r\n')
                         splittedLine = line.split(';')

--- a/prepareData/BuildP.py
+++ b/prepareData/BuildP.py
@@ -38,7 +38,7 @@ def buildP():
 
     with open('P.txt', 'w') as outFile:
         with open('hla_nom_p.txt') as file:
-            for line in file:
+            for line in sorted(file):
                 if not line.startswith('#'):
                     line = line.rstrip('\r\n')
                     splittedLine = line.split(';')


### PR DESCRIPTION
Hapl-o-Mat relies on sorted input from hla_nom_g.txt and hla_nom_p.txt
As this is not provided for in all IMGT/HLA-releases, a small patch in the Build files ensures the sorting.